### PR TITLE
Be compatible with The Silver Searcher

### DIFF
--- a/bgnotify.plugin.zsh
+++ b/bgnotify.plugin.zsh
@@ -7,6 +7,8 @@ zmodload zsh/datetime || { print "can't load zsh/datetime"; return } # faster th
 autoload -Uz add-zsh-hook || { print "can't add zsh hook!"; return }
 
 (( ${+bgnotify_threshold} )) || bgnotify_threshold=5 #default 10 seconds
+(( ${+bgnotify_icon} )) || bgnotify_icon=/usr/share/icons/Tango/32x32/apps/utilities-terminal.png
+
 
 
 ## definitions ##
@@ -40,7 +42,7 @@ bgnotify () { ## args: (title, subtitle)
   elif hash growlnotify 2>/dev/null; then #osx growl
     growlnotify -m "$1" "$2"
   elif hash notify-send 2>/dev/null; then #ubuntu gnome!
-    notify-send "$1" "$2"
+    notify-send -t 0 -i $bgnotify_icon "$1" "$2"
   elif hash kdialog 2>/dev/null; then #ubuntu kde!
     kdialog  -title "$1" --passivepopup  "$2" 5
   elif hash notifu 2>/dev/null; then #cygwyn support!

--- a/bgnotify.plugin.zsh
+++ b/bgnotify.plugin.zsh
@@ -11,7 +11,7 @@ autoload -Uz add-zsh-hook || { print "can't add zsh hook!"; return }
 
 ## definitions ##
 
-if ! (type bgnotify_formatted | grep -q 'function'); then ## allow custom function override
+if ! (type bgnotify_formatted | /bin/grep -q 'function'); then ## allow custom function override
   function bgnotify_formatted { ## args: (exit_status, command, elapsed_seconds)
     elapsed="$(( $3 % 60 ))s"
     (( $3 >= 60 )) && elapsed="$((( $3 % 3600) / 60 ))m $elapsed"


### PR DESCRIPTION
When grep aliased to [The Silver Searcher](https://github.com/ggreer/the_silver_searcher) (aka ag), zsh-background-notify produces error message on start, because ag complains it does not know -q flag.

This pull request ensures that system grep is used no matter what.
