### PR TITLE
Be compatible with The Silver Searcher

### DIFF
--- a/bgnotify.plugin.zsh
+++ b/bgnotify.plugin.zsh
@@ -11,7 +11,7 @@ autoload -Uz add-zsh-hook || { print "can't add zsh hook!"; return }
 
 ## definitions ##
 
-if ! (type bgnotify_formatted | grep -q 'function'); then ## allow custom function override
+if ! (type bgnotify_formatted | /bin/grep -q 'function'); then ## allow custom function override
   function bgnotify_formatted { ## args: (exit_status, command, elapsed_seconds)
     elapsed="$(( $3 % 60 ))s"
     (( $3 >= 60 )) && elapsed="$((( $3 % 3600) / 60 ))m $elapsed"


### PR DESCRIPTION
When grep is aliased to [The Silver Searcher](https://github.com/ggreer/the_silver_searcher) (aka ag), zsh-background-notify produces error message on zsh start, because ag complains it does not know -q flag.

This pull request ensures that system grep is used no matter what.