### PR TITLE
Add some improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ I do too! [Prezto](https://github.com/sorin-ionescu/prezto) rocks-- and works gr
 
 One can configure a few things:
 
-- `bgnotify_threshold` sets the notification threshold time (default 6 seconds)
+- `bgnotify_threshold` sets the notification threshold time (default 5 seconds)
 - `function notify_formatted` lets you change the notification
 
 Use these by adding a function definition before the your call to source. Example:

--- a/bgnotify.plugin.zsh
+++ b/bgnotify.plugin.zsh
@@ -6,14 +6,12 @@
 zmodload zsh/datetime || { print "can't load zsh/datetime"; return } # faster than date()
 autoload -Uz add-zsh-hook || { print "can't add zsh hook!"; return }
 
-(( ${+bgnotify_threshold} )) || bgnotify_threshold=5 #default 10 seconds
-
 
 ## definitions ##
 
-if ! (type bgnotify_formatted | grep -q 'function'); then ## allow custom function override
+if ! (( ${+functions[bgnotify_formatted]} )); then ## allow custom function override
   function bgnotify_formatted { ## args: (exit_status, command, elapsed_seconds)
-    elapsed="$(( $3 % 60 ))s"
+    local elapsed="$(( $3 % 60 ))s"
     (( $3 >= 60 )) && elapsed="$((( $3 % 3600) / 60 ))m $elapsed"
     (( $3 >= 3600 )) && elapsed="$(( $3 / 3600 ))h $elapsed"
     [ $1 -eq 0 ] && bgnotify "#win (took $elapsed)" "$2" || bgnotify "#fail (took $elapsed)" "$2"
@@ -21,9 +19,9 @@ if ! (type bgnotify_formatted | grep -q 'function'); then ## allow custom functi
 fi
 
 currentWindowId () {
-  if hash osascript 2>/dev/null; then #osx
+  if (( ${+commands[osascript]} )); then #osx
     osascript -e 'tell application (path to frontmost application as text) to id of front window' 2&> /dev/null || echo "0"
-  elif (hash notify-send 2>/dev/null || hash kdialog 2>/dev/null); then #ubuntu!
+  elif (( ${+commands[notify-send]} )) || (( ${+commands[kdialog]} )); then #ubuntu!
     xprop -root 2> /dev/null | awk '/NET_ACTIVE_WINDOW/{print $5;exit} END{exit !$5}' || echo "0"
   else
     echo $EPOCHSECONDS #fallback for windows
@@ -31,19 +29,19 @@ currentWindowId () {
 }
 
 bgnotify () { ## args: (title, subtitle)
-  if hash terminal-notifier 2>/dev/null; then #osx
+  if (( ${+commands[terminal-notifier]} )); then #osx
     [[ "$TERM_PROGRAM" == 'iTerm.app' ]] && term_id='com.googlecode.iterm2';
     [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] && term_id='com.apple.terminal';
     ## now call terminal-notifier, (hopefully with $term_id!)
     [ -z "$term_id" ] && terminal-notifier -message "$2" -title "$1" >/dev/null ||
     terminal-notifier -message "$2" -title "$1" -activate "$term_id" -sender "$term_id" >/dev/null
-  elif hash growlnotify 2>/dev/null; then #osx growl
+  elif (( ${+commands[growlnotify]} )); then #osx growl
     growlnotify -m "$1" "$2"
-  elif hash notify-send 2>/dev/null; then #ubuntu gnome!
+  elif (( ${+commands[notify-send]} )); then #ubuntu gnome!
     notify-send "$1" "$2"
-  elif hash kdialog 2>/dev/null; then #ubuntu kde!
+  elif (( ${+commands[kdialog]} )); then #ubuntu kde!
     kdialog  -title "$1" --passivepopup  "$2" 5
-  elif hash notifu 2>/dev/null; then #cygwyn support!
+  elif (( ${+commands[notifu]} )); then #cygwyn support!
     notifu /m "$2" /p "$1"
   fi
 }
@@ -58,9 +56,9 @@ bgnotify_begin() {
 }
 
 bgnotify_end() {
-  didexit=$?
-  elapsed=$(( EPOCHSECONDS - bgnotify_timestamp ))
-  past_threshold=$(( elapsed >= bgnotify_threshold ))
+  integer didexit=$?
+  integer elapsed=$(( EPOCHSECONDS - bgnotify_timestamp ))
+  integer past_threshold=$(( elapsed >= ${bgnotify_threshold:-5} ))
   if (( bgnotify_timestamp > 0 )) && (( past_threshold )); then
     if [ $(currentWindowId) != "$bgnotify_windowid" ]; then
       print -n "\a"


### PR DESCRIPTION
- For speed and simplicity, use expansions of parameter `functions` and `commands` to check whether function `bgnotify_formatted` is defined and commands to use exist each other.
- Make some parameters local ones.
- Remove initialization of parameter `bgnotify_threshold`.
- Fix description of `bgnotify_threshold` default value in README.