### PR TITLE
Fallback to xdotool to get focused window id

### DIFF
--- a/bgnotify.plugin.zsh
+++ b/bgnotify.plugin.zsh
@@ -24,7 +24,9 @@ currentWindowId () {
   if hash osascript 2>/dev/null; then #osx
     osascript -e 'tell application (path to frontmost application as text) to id of front window' 2&> /dev/null || echo "0"
   elif (hash notify-send 2>/dev/null || hash kdialog 2>/dev/null); then #ubuntu!
-    xprop -root 2> /dev/null | awk '/NET_ACTIVE_WINDOW/{print $5;exit} END{exit !$5}' || echo "0"
+    { xprop -root 2> /dev/null | awk '/NET_ACTIVE_WINDOW/{print $5;exit} END{exit !$5}' } || \
+      { hash xdotool && xdotool getwindowfocus } \
+      || echo "0"
   else
     echo $EPOCHSECONDS #fallback for windows
   fi


### PR DESCRIPTION
I'm using `xmonad` and it does not set `NET_ACTIVE_WINDOW` property. So fallback to `xdotool getwindowfocus` added.