### PR TITLE
Removed -sender from terminal-notifier invocation

### DIFF
--- a/bgnotify.plugin.zsh
+++ b/bgnotify.plugin.zsh
@@ -36,7 +36,7 @@ bgnotify () { ## args: (title, subtitle)
     [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] && term_id='com.apple.terminal';
     ## now call terminal-notifier, (hopefully with $term_id!)
     [ -z "$term_id" ] && terminal-notifier -message "$2" -title "$1" >/dev/null ||
-    terminal-notifier -message "$2" -title "$1" -activate "$term_id" -sender "$term_id" >/dev/null
+    terminal-notifier -message "$2" -title "$1" -activate "$term_id" >/dev/null
   elif hash growlnotify 2>/dev/null; then #osx growl
     growlnotify -m "$1" "$2"
   elif hash notify-send 2>/dev/null; then #ubuntu gnome!


### PR DESCRIPTION
Argument functionality has been removed and raises a warning as of terminal-notifier 3.0.0

See https://github.com/julienXX/terminal-notifier/releases/tag/3.0.0